### PR TITLE
Add a MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+include requirements.txt


### PR DESCRIPTION
Hi @keatonb :wave:  Awesome you started building a Period04 alternative!! :clap: 

Unfortunately it looks like `pip install pyriod` does not work right now because the `requirements.txt` file (used inside `setup.py`) is not included in the tarball that was sent to `pypi`:
```bash
$ pip install pyriod
Collecting pyriod
  Using cached https://files.pythonhosted.org/packages/62/00/0d13eedbf923b02e074de2b3946ea1ac488324eb51fa8806a066660e141c/Pyriod-0.0.1.tar.gz
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-646uifb8/pyriod/setup.py", line 6, in <module>
        with open("requirements.txt", "r") as fh:
    FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-646uifb8/pyriod/
```

The typical solution for this is to add a `MANIFEST.in` file to your repository, which tells `setup.py` which extra files need to be included in the source distribution tarball.  This PR adds such a file!

If you merge this PR, you can check that the issue is resolved as follows:
```bash
$ python setup.py sdist
$ tar -tvf dist/Pyriod-0.0.1.tar.gz | grep requirements.txt
-rw-r--r-- gb/gb            64 2019-07-19 09:38 Pyriod-0.0.1/requirements.txt
```

Success!  You can now upload this new tarball to `pypi` and the pip install should work!  (However note that pypi will require you to increase the version number.)

Let me know if you have any questions!